### PR TITLE
Inode + Rcnotify

### DIFF
--- a/cmd/systracer/main.go
+++ b/cmd/systracer/main.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/chaitin/systracer"
+	"github.com/chaitin/systracer/inode"
 )
 
 type moduleBarrier struct{}
@@ -78,6 +79,7 @@ var rootCmd = &cobra.Command{
 			defer logger.Sync()
 			return next(logger, sugaredLogger)
 		}),
+		inode.Module,
 	)).RunE,
 }
 

--- a/cmd/systracer/watch.go
+++ b/cmd/systracer/watch.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/aegistudio/shaft"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/chaitin/systracer/rcnotify"
+)
+
+var (
+	watches []string
+)
+
+func initWatchModule() shaft.Option {
+	if len(watches) == 0 {
+		return shaft.Module()
+	}
+	return shaft.Module(
+		rcnotify.Module,
+		shaft.Provide(func(
+			ctx context.Context, group *errgroup.Group,
+			logger *zap.SugaredLogger, manager *rcnotify.Manager,
+		) ([]moduleBarrier, error) {
+			// Attempt to parse the watch argumets.
+			var options []rcnotify.Option
+			for _, watch := range watches {
+				pathIndex := strings.Index(watch, "=")
+				if pathIndex <= 0 {
+					return nil, errors.New(
+						`"watch must be of format "<events>=<path>"`)
+				}
+				events := watch[:pathIndex]
+				path := watch[pathIndex+1:]
+				var matcher func(rcnotify.Op, string) rcnotify.Option
+				matcher = rcnotify.WatchDir
+				var flags rcnotify.Op
+				for _, event := range strings.Split(events, ",") {
+					switch event {
+					case "all":
+						flags |= rcnotify.OpAll
+					case "create":
+						flags |= rcnotify.OpCreate
+					case "mknod":
+						flags |= rcnotify.OpMknod
+					case "mkdir":
+						flags |= rcnotify.OpMkdir
+					case "delete":
+						flags |= rcnotify.OpDelete
+					case "rmdir":
+						flags |= rcnotify.OpRmdir
+					case "rename":
+						flags |= rcnotify.OpRename
+					case "attrib":
+						flags |= rcnotify.OpAttrib
+					case "link":
+						flags |= rcnotify.OpLink
+					case "symlink":
+						flags |= rcnotify.OpSymlink
+					case "dir":
+						matcher = rcnotify.WatchDir
+					case "file":
+						matcher = rcnotify.WatchFile
+					default:
+						return nil, errors.Errorf(
+							"unknown event %q", event)
+					}
+				}
+				options = append(options, matcher(flags, path))
+			}
+			watcher, err := manager.Watch(options...)
+			if err != nil {
+				return nil, err
+			}
+			group.Go(func() error {
+				defer watcher.Close()
+				for {
+					var event rcnotify.Event
+					select {
+					case <-ctx.Done():
+						return nil
+					case event = <-watcher.C:
+					}
+					eventContext := fmt.Sprintf("%s %d",
+						event.Timestamp.Format("2006-01-02T15:04:05.999999999"), event.PID)
+					sourcePath := "(unknown)"
+					if event.Source != nil {
+						sourcePath = fmt.Sprintf("%q", *event.Source)
+					}
+					targetPath := "(unknown)"
+					if event.Target != nil {
+						targetPath = fmt.Sprintf("%q", *event.Target)
+					}
+					var fileMode os.FileMode
+					if event.Mode != nil {
+						fileMode = os.FileMode(*event.Mode & 0777)
+						switch *event.Mode & syscall.S_IFMT {
+						case syscall.S_IFBLK:
+							fileMode |= os.ModeDevice
+						case syscall.S_IFCHR:
+							fileMode |= os.ModeDevice | os.ModeCharDevice
+						case syscall.S_IFDIR:
+							fileMode |= os.ModeDir
+						case syscall.S_IFIFO:
+							fileMode |= os.ModeNamedPipe
+						case syscall.S_IFLNK:
+							fileMode |= os.ModeSymlink
+						case syscall.S_IFREG:
+							// nothing to do
+						case syscall.S_IFSOCK:
+							fileMode |= os.ModeSocket
+						}
+						if (*event.Mode & syscall.S_ISGID) != 0 {
+							fileMode |= os.ModeSetgid
+						}
+						if (*event.Mode & syscall.S_ISUID) != 0 {
+							fileMode |= os.ModeSetuid
+						}
+						if (*event.Mode & syscall.S_ISVTX) != 0 {
+							fileMode |= os.ModeSticky
+						}
+					}
+					switch event.Op {
+					case rcnotify.OpCreate:
+						logger.Infof("%s - create(%s, %q)",
+							eventContext, targetPath, fileMode)
+					case rcnotify.OpMkdir:
+						logger.Infof("%s - mkdir(%s, %q)",
+							eventContext, targetPath, fileMode)
+					case rcnotify.OpMknod:
+						logger.Infof("%s - mknod(%s, %q, %d)",
+							eventContext, targetPath,
+							fileMode, *event.Dev)
+					case rcnotify.OpDelete:
+						logger.Infof("%s - delete(%s)",
+							eventContext, targetPath)
+					case rcnotify.OpRmdir:
+						logger.Infof("%s - rmdir(%s)",
+							eventContext, targetPath)
+					case rcnotify.OpRename:
+						logger.Infof("%s - rename(%s, %s)",
+							eventContext, sourcePath, targetPath)
+					case rcnotify.OpAttrib:
+						if event.Attr&rcnotify.AttrMode != 0 {
+							logger.Infof("%s - chmod(%s, %q)",
+								eventContext, targetPath, fileMode)
+						}
+						if event.Attr&rcnotify.AttrUID != 0 {
+							logger.Infof("%s - chown_uid(%s, %d)",
+								eventContext, targetPath, *event.Uid)
+						}
+						if event.Attr&rcnotify.AttrGID != 0 {
+							logger.Infof("%s - chown_gid(%s, %d)",
+								eventContext, targetPath, *event.Gid)
+						}
+					case rcnotify.OpLink:
+						logger.Infof("%s - link(%s, %s)",
+							eventContext, sourcePath, targetPath)
+					case rcnotify.OpSymlink:
+						logger.Infof("%s - symlink(%s, %s)",
+							eventContext, sourcePath, targetPath)
+					}
+				}
+				return nil
+			})
+			return nil, nil
+		}),
+	)
+}
+
+func init() {
+	moduleInits = append(moduleInits, initWatchModule)
+	rootCmd.PersistentFlags().StringArrayVarP(
+		&watches, "watch", "w", watches,
+		"specify list of watches for directory events")
+}

--- a/inode/inode.go
+++ b/inode/inode.go
@@ -1,0 +1,455 @@
+// Package inode provides service for uniquely pinning and
+// addressing an inode for path.
+package inode
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/aegistudio/shaft"
+	"github.com/pkg/errors"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/chaitin/systracer"
+	"github.com/chaitin/systracer/pkg/alloc"
+	"github.com/chaitin/systracer/pkg/kversion"
+)
+
+// inodePinResult is the response captured corresponding to
+// each inode pinning request.
+type inodePinResult struct {
+	inode, cookie uint64
+}
+
+// collector is the collector for receiving the reaction of
+// the inode pinning, and send it back to the master thread.
+type collector struct {
+	rootCtx  context.Context
+	resultCh chan<- inodePinResult
+}
+
+// handleInodePin is the handler for inode pinning captured
+// by security_inode_getsecurity. We filter out only the
+// "security.systracer.inode_pin.*".
+func (col *collector) handleInodePin(
+	name string, inode uint64,
+) {
+	prefix := "systracer.inode_pin."
+	if !strings.HasPrefix(name, prefix) {
+		return
+	}
+	cookie, err := strconv.ParseUint(
+		name[len(prefix):], 16, 64)
+	if err != nil {
+		return
+	}
+	result := inodePinResult{
+		inode:  inode,
+		cookie: cookie,
+	}
+	select {
+	case <-col.rootCtx.Done():
+	case col.resultCh <- result:
+	}
+}
+
+// handleSecurityInodePin handles the inode pinning event
+// from version 2.6.24 (inclusive) to 5.12 (exclusive).
+//
+// security_inode_getsecurity(
+//    Inode, "systracer.inode_pin.${hex Cookie}")
+func (col *collector) handleSecurityInodePin_V2_6_24(
+	event entrySecurityInodePin_V2_6_24,
+) {
+	col.handleInodePin(event.Name, event.Inode)
+}
+
+// handleSecurityInodePin handles the inode pinning event
+// from 5.12 (inclusive) to now.
+//
+// security_inode_getsecurity(
+//    MountNS, Inode, "systracer.inode_pin.${hex Cookie}")
+func (col *collector) handleSecurityInodePin_V5_12(
+	event entrySecurityInodePin_V5_12,
+) {
+	col.handleInodePin(event.Name, event.Inode)
+}
+
+// inodePin is the state of deduplicated inode which holds
+// strong reference to the open inode to keep the validity
+// of the addressing result.
+type inodePin struct {
+	id     uint64
+	name   string
+	inode  uint64
+	file   *os.File
+	ref    uint64
+	doneCh chan struct{}
+}
+
+// Inode is the actually pinned inode.
+type Inode struct {
+	manager *Manager
+	inner   *inodePin
+	once    sync.Once
+}
+
+// Inode returns the address of the pinned inode.
+func (inode *Inode) Inode() uint64 {
+	return inode.inner.inode
+}
+
+// Unpin removes the strong reference held by caller.
+func (inode *Inode) Unpin() {
+	inode.once.Do(func() {
+		inode.manager.unpin(inode.inner)
+	})
+	runtime.SetFinalizer(inode, nil)
+}
+
+// inodePinRequest for performing inode pinning.
+type inodePinRequest struct {
+	name   string
+	mode   int
+	doneCh chan struct{}
+	result *inodePin
+	err    error
+}
+
+// Manager for performing and managing inode pins.
+type Manager struct {
+	rootCtx context.Context
+	pinCh   chan *inodePinRequest
+	unpinCh chan *inodePin
+}
+
+// pin requests for requesting and opening an inode pin.
+func (m *Manager) pin(name string, mode int) (*Inode, error) {
+	abs, err := filepath.Abs(name)
+	if err != nil {
+		return nil, err
+	}
+	req := &inodePinRequest{
+		name:   abs,
+		mode:   mode,
+		doneCh: make(chan struct{}),
+	}
+	select {
+	case <-m.rootCtx.Done():
+		return nil, m.rootCtx.Err()
+	case m.pinCh <- req:
+	}
+	select {
+	case <-m.rootCtx.Done():
+		return nil, m.rootCtx.Err()
+	case <-req.doneCh:
+	}
+	if req.err != nil {
+		return nil, req.err
+	}
+	select {
+	case <-m.rootCtx.Done():
+		return nil, m.rootCtx.Err()
+	case <-req.result.doneCh:
+	}
+	result := &Inode{
+		inner:   req.result,
+		manager: m,
+	}
+	runtime.SetFinalizer(result, func(value *Inode) {
+		value.Unpin()
+	})
+	return result, nil
+}
+
+// PinFile is the request for pinning single file.
+func (m *Manager) PinFile(name string) (*Inode, error) {
+	return m.pin(name, syscall.O_RDONLY|syscall.O_CLOEXEC)
+}
+
+// PinDir is the request for pinning single dir.
+func (m *Manager) PinDir(name string) (*Inode, error) {
+	return m.pin(name,
+		syscall.O_RDONLY|syscall.O_DIRECTORY|syscall.O_CLOEXEC)
+}
+
+// unpin is the request for closing an inode pin.
+func (m *Manager) unpin(p *inodePin) {
+	select {
+	case <-m.rootCtx.Done():
+	case m.unpinCh <- p:
+	}
+}
+
+// managerState is the state triggered by
+// either pin completion event, retest timers and
+// registrations/unregistrations.
+type managerState struct {
+	last       uint64
+	cookieBase uint64
+
+	all     map[uint64]*inodePin
+	names   map[string]*inodePin
+	cookies map[uint64]*inodePin
+}
+
+// close destroys all allocated instances in the state.
+func (s *managerState) close() {
+	for _, pin := range s.all {
+		_ = pin.file.Close()
+		pin.id = 0
+	}
+}
+
+// performInodePin executes the actual inode pinning with
+// our specified fd and cookie.
+func performInodePin(fd uintptr, cookie uint64) {
+	filename := fmt.Sprintf("/proc/self/fd/%d", fd)
+	attribute := fmt.Sprintf(
+		"security.systracer.inode_pin.%x", cookie)
+	var buf [1024]byte
+	_, _ = syscall.Getxattr(filename, attribute, buf[:])
+}
+
+// pin attempts to allocate and create a pin in the state.
+func (s *managerState) pin(
+	name string, flag int,
+) (rpin *inodePin, rerr error) {
+	// Attempt to open the specified file for later use,
+	// please notice that the file might be swapped for
+	// later use and will not close then.
+	fd, err := syscall.Open(name, flag, 0)
+	if err != nil {
+		return nil, err
+	}
+	f := os.NewFile(uintptr(fd), name)
+	defer func() {
+		if f != nil {
+			_ = f.Close()
+		}
+	}()
+
+	// If there's previous node for the file, attempt to
+	// allocate specified node for the file.
+	if previous, ok := s.names[name]; ok {
+		// Retrieve previous and current file information.
+		newInfo, err := f.Stat()
+		if err != nil {
+			return nil, err
+		}
+		newStat := newInfo.Sys().(*syscall.Stat_t)
+		oldInfo, err := previous.file.Stat()
+		if err != nil {
+			return nil, err
+		}
+		oldStat := oldInfo.Sys().(*syscall.Stat_t)
+
+		// Compare the information and return the previous
+		// one if they are the same.
+		if newStat.Dev == oldStat.Dev &&
+			newStat.Ino == oldStat.Ino &&
+			newStat.Rdev == oldStat.Rdev {
+			previous.ref++
+			return previous, nil
+		}
+	}
+
+	// Attempt to allocate a new node for the subscription.
+	id := alloc.Alloc(s.last, uint64(1<<48), func(id uint64) bool {
+		return s.all[id] != nil
+	})
+	if id == 0 {
+		return nil, errors.New(
+			"cannot allocate more inode pin")
+	}
+	created := &inodePin{
+		id:     id,
+		name:   name,
+		file:   f,
+		ref:    1,
+		doneCh: make(chan struct{}),
+	}
+	s.all[id] = created
+	s.last = id
+	s.names[name] = created
+	f = nil
+
+	// Mark the file and create a new cookie here.
+	s.cookieBase++
+	cookie := s.cookieBase
+	s.cookies[cookie] = created
+	performInodePin(created.file.Fd(), cookie)
+	return created, nil
+}
+
+// unpin attempts to decrement reference and potentially
+// remove a pin from the state.
+func (s *managerState) unpin(p *inodePin) {
+	if p.id == 0 {
+		return
+	}
+	p.ref--
+	if p.ref > 0 {
+		return
+	}
+	if s.names[p.name] == p {
+		delete(s.names, p.name)
+	}
+	delete(s.all, p.id)
+	if p.file != nil {
+		_ = p.file.Close()
+		p.file = nil
+	}
+	p.id = 0
+}
+
+// reallocateCookie will attempt to reset current cookies.
+func (s *managerState) reallocateCookie() {
+	newCookies := make(map[uint64]*inodePin)
+	for _, target := range s.cookies {
+		if target.id == 0 {
+			continue
+		}
+		s.cookieBase++
+		cookie := s.cookieBase
+		newCookies[cookie] = target
+		performInodePin(target.file.Fd(), cookie)
+	}
+	s.cookies = newCookies
+}
+
+// handleResult handles the inode pin result.
+func (s *managerState) handleResult(
+	event inodePinResult,
+) {
+	target := s.cookies[event.cookie]
+	if target == nil {
+		return
+	}
+	delete(s.cookies, event.cookie)
+	target.inode = event.inode
+	close(target.doneCh)
+}
+
+// hasPending see whether there's pending pind request.
+func (s *managerState) hasPending() bool {
+	return len(s.cookies) != 0
+}
+
+// runMasterThread executes the master thread.
+func (m *Manager) runMasterThread(
+	resultCh <-chan inodePinResult,
+) {
+	var ticker *time.Ticker
+	defer func() {
+		if ticker != nil {
+			ticker.Stop()
+		}
+	}()
+	state := &managerState{
+		all:     make(map[uint64]*inodePin),
+		names:   make(map[string]*inodePin),
+		cookies: make(map[uint64]*inodePin),
+	}
+	defer state.close()
+	for {
+		var tickCh <-chan time.Time
+		if ticker != nil {
+			tickCh = ticker.C
+		}
+
+		// Serve user request, inode pin event and
+		// reallocate tick within select.
+		select {
+		case <-m.rootCtx.Done():
+			return
+		case event := <-resultCh:
+			state.handleResult(event)
+		case req := <-m.pinCh:
+			func() {
+				defer close(req.doneCh)
+				req.result, req.err = state.pin(
+					req.name, req.mode)
+			}()
+		case req := <-m.unpinCh:
+			state.unpin(req)
+		case <-tickCh:
+			state.reallocateCookie()
+		}
+
+		// Setup or shutdown current reallocate ticker.
+		if state.hasPending() {
+			if ticker == nil {
+				ticker = time.NewTicker(5 * time.Second)
+			}
+		} else {
+			if ticker != nil {
+				ticker.Stop()
+				ticker = nil
+			}
+		}
+	}
+}
+
+// stackInodeManager will attempt to create an inode pin
+// manager and stack it for later operations.
+func stackInodeManager(
+	next func(*Manager) error,
+	rootCtx context.Context, group *errgroup.Group,
+	manager systracer.Manager,
+) error {
+	// Setup the collector for receiving events.
+	resultCh := make(chan inodePinResult)
+	collector := &collector{
+		rootCtx:  rootCtx,
+		resultCh: resultCh,
+	}
+
+	// Attach to the security_inode_getsecurity
+	// for receiving file hook result.
+	var target interface{}
+	target = collector.handleSecurityInodePin_V2_6_24
+	if kversion.Current >= kversion.Must("5.12") {
+		target = collector.handleSecurityInodePin_V5_12
+	}
+	inodePinProbe, syncCh, err := manager.TraceKProbe(
+		"security_inode_getsecurity", target)
+	if err != nil {
+		return err
+	}
+	defer inodePinProbe.Close()
+
+	// Wait for the completion of probe creation.
+	select {
+	case <-rootCtx.Done():
+		return nil
+	case <-syncCh:
+	}
+
+	// Startup the inode pin master thread.
+	result := &Manager{
+		rootCtx: rootCtx,
+		pinCh:   make(chan *inodePinRequest),
+		unpinCh: make(chan *inodePin),
+	}
+	group.Go(func() error {
+		inodePinProbe.SetEnabled(true)
+		result.runMasterThread(resultCh)
+		return nil
+	})
+	return next(result)
+}
+
+// Module is the DI module of the inode manager.
+//
+// The module requires a context, an errgroup and a trace
+// manager, and injects an inode pin manager.
+var Module = shaft.Stack(stackInodeManager)

--- a/inode/trace_386.go
+++ b/inode/trace_386.go
@@ -1,0 +1,17 @@
+package inode
+
+import (
+	"github.com/chaitin/systracer"
+)
+
+type entrySecurityInodePin_V2_6_24 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%ax"`
+	Name  string `tracing:"%dx,Name ~ \"systracer.inode_pin.*\""`
+}
+
+type entrySecurityInodePin_V5_12 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%dx"`
+	Name  string `tracing:"%cx,Name ~ \"systracer.inode_pin.*\""`
+}

--- a/inode/trace_amd64.go
+++ b/inode/trace_amd64.go
@@ -1,0 +1,17 @@
+package inode
+
+import (
+	"github.com/chaitin/systracer"
+)
+
+type entrySecurityInodePin_V2_6_24 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%di"`
+	Name  string `tracing:"%si,Name ~ \"systracer.inode_pin.*\""`
+}
+
+type entrySecurityInodePin_V5_12 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%si"`
+	Name  string `tracing:"%dx,Name ~ \"systracer.inode_pin.*\""`
+}

--- a/inode/trace_arm64.go
+++ b/inode/trace_arm64.go
@@ -1,0 +1,17 @@
+package inode
+
+import (
+	"github.com/chaitin/systracer"
+)
+
+type entrySecurityInodePin_V2_6_24 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%x0"`
+	Name  string `tracing:"%x1,Name ~ \"systracer.inode_pin.*\""`
+}
+
+type entrySecurityInodePin_V5_12 struct {
+	systracer.ProbeEvent
+	Inode uint64 `tracing:"%x1"`
+	Name  string `tracing:"%x2,Name ~ \"systracer.inode_pin.*\""`
+}

--- a/manager.go
+++ b/manager.go
@@ -646,11 +646,13 @@ var minimumTickerInterval = 50 * time.Millisecond
 func (mgr *traceManager) runWriterThread(
 	syncCh <-chan *synchronizeRegistryRequest,
 	receiveCh <-chan []byte, limitInterval time.Duration,
+	logger *zap.SugaredLogger,
 ) error {
 	// Writer state for handling the dispatch relation
 	// of the trace data payload.
 	state := &traceWriterState{
 		registries: make(map[uint64]*traceHandle),
+		logger:     logger,
 	}
 
 	// Initialize the ticker which limits the reader
@@ -910,7 +912,7 @@ func newInternal(
 	})
 	group.Go(func() error {
 		return manager.runWriterThread(
-			syncCh, receiveCh, option.limitInterval)
+			syncCh, receiveCh, option.limitInterval, logger)
 	})
 	hasCreated = true
 	return manager, nil

--- a/rcnotify/rcnotify.go
+++ b/rcnotify/rcnotify.go
@@ -1,0 +1,952 @@
+package rcnotify
+
+import (
+	"context"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/aegistudio/shaft"
+	"github.com/pkg/errors"
+
+	"github.com/chaitin/systracer"
+	"github.com/chaitin/systracer/inode"
+	"github.com/chaitin/systracer/pkg/kversion"
+)
+
+// extractPathComponent is the code for creating a
+// valid portion of path component.
+func extractPathComponent(src []systracer.StringAddr) []string {
+	var result []string
+	for i := 0; i < len(src); i++ {
+		if src[i].Addr == 0 {
+			break
+		}
+		if i > 0 && src[i].Addr == src[i-1].Addr {
+			break
+		}
+		result = append(result, src[i].String)
+	}
+	return result
+}
+
+// Op is the file event op for linux.
+//
+// The event operations are defined dedicated for linux,
+// and some extra information will be filled based on
+// different event type.
+//
+// The operations can be or-ed together to represent
+// set of events for notification.
+type Op uint64
+
+const (
+	OpCreate = Op(1 << iota)
+	OpMkdir
+	OpMknod
+	OpDelete
+	OpRmdir
+	OpRename
+	OpAttrib
+	OpLink
+	OpSymlink
+
+	OpAll = OpCreate | OpMkdir | OpDelete | OpRmdir |
+		OpRename | OpAttrib | OpLink | OpSymlink
+)
+
+// Attr indicates valid fields in the attribute event.
+//
+// These fields are or-ed together to represent the set
+// of fields that has been updated by the event.
+type Attr uint32
+
+const (
+	AttrMode = Attr(1 << iota)
+	AttrUID
+	AttrGID
+)
+
+// eventRaw is the trasported event on linux waiting
+// to be dispatched to master.
+//
+// Master should translate and lookup using the source
+// and target path and translate file events.
+type eventRaw struct {
+	op        Op
+	timestamp time.Time
+	pid       uint32
+	source    path
+	target    path
+	attr      Attr
+	mode      *uint16
+	dev       *uint32
+	symlink   *string
+	uid       *uint32
+	gid       *uint32
+}
+
+// eventRegistry is the common registry holding
+// information used for later notification.
+type eventRegistry struct {
+	event       eventRaw
+	targetInode uint64
+	sourceInode uint64
+}
+
+// Event is standard format of linux directory event.
+type Event struct {
+	Op        Op
+	Timestamp time.Time
+	PID       uint32
+	Target    *string
+	Source    *string
+	Attr      Attr
+	Mode      *uint16
+	Dev       *uint32
+	Uid       *uint32
+	Gid       *uint32
+}
+
+// dispatchPolicy stores information for the dispatcher,
+// including the file name corresponding to inode, and
+// its related flags.
+//
+// while dispatching events, the subscriber works in a
+// hierarchical manner, the dispatch policy nearer to
+// the leaf will be applied first.
+type dispatchPolicy struct {
+	name    string
+	opFlags Op
+}
+
+// subscriber stores the information for dispatching
+// the subscribed events to the subscriber.
+type subscriber struct {
+	ctx        context.Context
+	done       *uint8
+	allOpFlags Op
+	eventCh    chan<- Event
+	policies   map[uint64]dispatchPolicy
+}
+
+// composeSuffix composes the suffix with path.
+func composeSuffix(components []string) string {
+	size := len(components)
+	result := make([]string, size)
+	for j := 0; j < size; j++ {
+		result[j] = components[size-j-1]
+	}
+	return filepath.Join(result...)
+}
+
+// evaluatePathPolicy attempts to evaluate the path and
+// calculate the policies for the path.
+func (s *subscriber) evaluatePathPolicy(p path) (*string, Op) {
+	paths, inodes := p.extract()
+	for i, inode := range inodes {
+		if inode == 0 {
+			continue
+		}
+		policy, ok := s.policies[inode]
+		if !ok {
+			continue
+		}
+		targetSuffix := composeSuffix(paths[:i])
+		result := new(string)
+		*result = filepath.Join(policy.name, targetSuffix)
+		return result, policy.opFlags
+	}
+	return nil, Op(0)
+}
+
+// dispatch is the handler for dispatching event
+// to receivers.
+func (s *subscriber) dispatch(
+	rawEvent eventRaw, visited *uint8,
+) {
+	if s.done == visited {
+		// The event has already been dispatched,
+		// so we won't dispatch it again here.
+		return
+	}
+	s.done = visited
+	if s.allOpFlags&rawEvent.op == 0 {
+		return
+	}
+
+	// Prepare the base for the new dispatching of
+	// specified file event.
+	var event Event
+	event.Op = rawEvent.op
+	event.PID = rawEvent.pid
+	event.Timestamp = rawEvent.timestamp
+	event.Attr = rawEvent.attr
+	event.Mode = rawEvent.mode
+	event.Dev = rawEvent.dev
+	event.Uid = rawEvent.uid
+	event.Gid = rawEvent.gid
+	event.Source = rawEvent.symlink
+
+	// Compose the path parameters for the event.
+	var opFlags, allFlags Op
+	event.Target, allFlags = s.evaluatePathPolicy(rawEvent.target)
+	switch rawEvent.op {
+	case OpRename, OpLink:
+		event.Source, opFlags = s.evaluatePathPolicy(rawEvent.source)
+		allFlags |= opFlags
+	case OpSymlink:
+		event.Source = rawEvent.symlink
+	}
+
+	// Dispatch the collected event to subscriber.
+	if allFlags&rawEvent.op == 0 {
+		return
+	}
+	select {
+	case <-s.ctx.Done():
+	case s.eventCh <- event:
+	}
+}
+
+// collector is the collector for the linux file related
+// events. It keeps track of file state registries and
+// will periodically perform cleanup.
+type collector struct {
+	registries  map[uint32]*eventRegistry
+	dispatchMap *sync.Map
+}
+
+// allocateRename will attempt to allocate a new
+// or previously existing registry for rename.
+func (col *collector) allocateRename(
+	taskPID uint32, event entrySecurityInodeRename,
+) *eventRegistry {
+	registry := col.registries[taskPID]
+	if registry != nil {
+		if registry.event.op != OpRename ||
+			registry.sourceInode != event.SrcDir ||
+			registry.targetInode != event.DstDir {
+			delete(col.registries, taskPID)
+			registry = nil
+		}
+	}
+	if registry == nil {
+		registry = &eventRegistry{
+			event: eventRaw{
+				op: OpRename,
+			},
+			sourceInode: event.SrcDir,
+			targetInode: event.DstDir,
+		}
+		col.registries[taskPID] = registry
+	}
+	return registry
+}
+
+// handleRenameSource handles the event triggered
+// when renaming the file and is captured by our
+// trace probe.
+//
+// security_inode_rename(sourcePath, &dentry{
+//    <d_name,d_path> = Source,
+// }, targetPath, ...)
+func (col *collector) handleRenameSource(
+	event entrySecurityInodeRenameSource,
+) {
+	registry := col.allocateRename(
+		event.TaskPID, event.Event)
+	registry.event.source = event.Source
+}
+
+// handleRenameTarget handles the event triggered
+// when renaming the file and is captured by our
+// trace probe.
+//
+// security_inode_rename(sourcePath, ...,
+//    targetPath, &dentry{
+//       <d_name,d_path> = Target,
+//    })
+func (col *collector) handleRenameTarget(
+	event entrySecurityInodeRenameTarget,
+) {
+	registry := col.allocateRename(
+		event.TaskPID, event.Event)
+	registry.event.target = event.Target
+}
+
+// handleCreate handles the event triggered when
+// creating a file and is captured by our trace probe.
+//
+// security_inode_create(targetInode, &dentry{
+//    <d_name,d_path> = targetPath,
+// }, mode, dev)
+func (col *collector) handleCreate(
+	event entrySecurityInodeCreate,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpCreate,
+			mode:   new(uint16),
+			target: event.Path,
+		},
+		targetInode: event.Dir,
+	}
+	*registry.event.mode = event.Mode
+	col.registries[event.TaskPID] = registry
+}
+
+// handleMknod handles the event triggered when
+// creating a device and is captured by our
+// trace probe.
+//
+// security_inode_mknod(targetInode, &dentry{
+//    <d_name,d_path> = targetPath,
+// }, mode, dev)
+func (col *collector) handleMknod(
+	event entrySecurityInodeMknod,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpMknod,
+			mode:   new(uint16),
+			dev:    new(uint32),
+			target: event.Path,
+		},
+		targetInode: event.Dir,
+	}
+	*registry.event.mode = event.Mode
+	*registry.event.dev = event.Dev
+	col.registries[event.TaskPID] = registry
+}
+
+// handleMkdir handles the event triggered when
+// creating a direcotry and is captured by our
+// trace probe.
+//
+// security_inode_mkdir(targetInode, &dentry{
+//    <d_name,d_path> = targetPath,
+// }, mode)
+func (col *collector) handleMkdir(
+	event entrySecurityInodeMkdir,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpMkdir,
+			mode:   new(uint16),
+			target: event.Path,
+		},
+		targetInode: event.Dir,
+	}
+	*registry.event.mode = event.Mode
+	col.registries[event.TaskPID] = registry
+}
+
+// allocateLink will attempt to allocate a new
+// or previously existing registry for link.
+func (col *collector) allocateLink(
+	taskPID uint32, event entrySecurityInodeLink,
+) *eventRegistry {
+	registry := col.registries[taskPID]
+	if registry != nil {
+		if registry.event.op != OpLink ||
+			registry.targetInode != event.Dir {
+			delete(col.registries, taskPID)
+			registry = nil
+		}
+	}
+	if registry == nil {
+		registry = &eventRegistry{
+			event: eventRaw{
+				op: OpLink,
+			},
+			targetInode: event.Dir,
+		}
+		col.registries[taskPID] = registry
+	}
+	return registry
+}
+
+// handleLinkSource handles the event triggered
+// when creating hard link of the file and is captured
+// by our trace probe.
+//
+// security_inode_link(source, &dentry{
+//    <d_name,d_path> = Dir,
+// }, ...)
+func (col *collector) handleLinkSource(
+	event entrySecurityInodeLinkSource,
+) {
+	registry := col.allocateLink(
+		event.TaskPID, event.Event)
+	registry.event.source = event.Source
+}
+
+// handleRenameTarget handles the event triggered
+// when creating hard link of the file and is captured
+// by our trace probe.
+//
+// security_inode_link(..., &dentry{
+//    <d_name,d_path> = Target,
+// }, target)
+func (col *collector) handleLinkTarget(
+	event entrySecurityInodeLinkTarget,
+) {
+	registry := col.allocateLink(
+		event.TaskPID, event.Event)
+	registry.event.target = event.Target
+}
+
+// handleSymlink handles the event triggered when
+// creating soft link of the file and is captured by
+// our trace probe.
+//
+// security_inode_symlink(targetInode, &dentry{
+//    <d_name,d_path> = Target,
+// }, source)
+func (col *collector) handleSymlink(
+	event entrySecurityInodeSymlink,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:      OpSymlink,
+			target:  event.Path,
+			symlink: new(string),
+		},
+		targetInode: event.Dir,
+	}
+	*registry.event.symlink = event.Name
+	col.registries[event.TaskPID] = registry
+}
+
+// handleUnlink handles the event triggered when
+// removing a file and is captured by our trace probe.
+//
+// security_inode_unlink(targetInode, &dentry{
+//    <d_name,d_path> = targetPath,
+// })
+func (col *collector) handleUnlink(
+	event entrySecurityInodeUnlink,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpDelete,
+			target: event.Path,
+		},
+		targetInode: event.Path.I0,
+	}
+	col.registries[event.TaskPID] = registry
+}
+
+// handleRmdir handles the event triggered when
+// removing a direcotry and is captured by our
+// trace probe.
+//
+// security_inode_rmdir(targetInode, &dentry{
+//    <d_name,d_path> = targetPath,
+// })
+func (col *collector) handleRmdir(
+	event entrySecurityInodeRmdir,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpRmdir,
+			target: event.Path,
+		},
+		targetInode: event.Path.I0,
+	}
+	col.registries[event.TaskPID] = registry
+}
+
+// handleSetattr handles the event triggered when
+// updating a file attributes and is captured by
+// our trace probe.
+//
+// security_inode_setattr(&dentry{
+//    <d_name,d_path> = targetPath,
+// }, &iattr{
+//    ia_mode = Mode,
+//    ia_uid  = Uid,
+//    ia_gid  = Gid,
+// })
+func (col *collector) handleSetattr(
+	event entrySecurityInodeSetattr,
+) {
+	registry := &eventRegistry{
+		event: eventRaw{
+			op:     OpAttrib,
+			target: event.Path,
+		},
+		targetInode: event.Path.I0,
+	}
+	if Attr(event.Valid)&AttrMode != 0 {
+		registry.event.attr |= AttrMode
+		registry.event.mode = new(uint16)
+		*registry.event.mode = event.Mode
+	}
+	if Attr(event.Valid)&AttrUID != 0 {
+		registry.event.attr |= AttrUID
+		registry.event.uid = new(uint32)
+		*registry.event.uid = event.Uid
+	}
+	if Attr(event.Valid)&AttrGID != 0 {
+		registry.event.attr |= AttrGID
+		registry.event.gid = new(uint32)
+		*registry.event.gid = event.Gid
+	}
+	if registry.event.attr == 0 {
+		// No event we are interested, so we will
+		// just skip reporting the events.
+		return
+	}
+	col.registries[event.TaskPID] = registry
+}
+
+// handleFsnotify_V2_6_32 handles the fsnotify event
+// from 2.6.32 (inclusive) to 5.9 (exclusive).
+func (col *collector) handleFsnotify_V2_6_32(
+	event entryFsnotify_V2_6_32,
+) {
+	if _, ok := col.registries[event.TaskPID]; !ok {
+		return
+	}
+	col.handleFsnotify(eventFsnotify{
+		TaskPID:      event.TaskPID,
+		Timestamp:    event.Timestamp,
+		Inode:        uint64(event.Inode),
+		Access:       event.Access,
+		ModifyAttrib: event.ModifyAttrib,
+		CloseOpen:    event.CloseOpen,
+		Dentry:       event.Dentry,
+		Filename:     event.Filename,
+	})
+}
+
+// handleFsnotify_V5_9 handles the fsnotify event
+// from 5.9 (inclusive) to now.
+func (col *collector) handleFsnotify_V5_9(
+	event entryFsnotify_V5_9,
+) {
+	if _, ok := col.registries[event.TaskPID]; !ok {
+		return
+	}
+	baseEvent := eventFsnotify{
+		TaskPID:      event.TaskPID,
+		Timestamp:    event.Timestamp,
+		Access:       event.Access,
+		ModifyAttrib: event.ModifyAttrib,
+		CloseOpen:    event.CloseOpen,
+		Dentry:       event.Dentry,
+		Filename:     event.Filename,
+		Visited:      new(uint8),
+	}
+	if event.Inode != 0 {
+		baseEvent.Inode = uint64(event.Inode)
+		col.handleFsnotify(baseEvent)
+	}
+	if event.Dir != 0 {
+		baseEvent.Inode = uint64(event.Dir)
+		col.handleFsnotify(baseEvent)
+	}
+}
+
+// handleFsnotifyParent_V5_9 handles the fsnotify
+// parent event from 5.9 (inclusive) to now.
+func (col *collector) handleFsnotifyParent_V5_9(
+	event entryFsnotifyParent_V5_9,
+) {
+	if _, ok := col.registries[event.TaskPID]; !ok {
+		return
+	}
+	col.handleFsnotify(eventFsnotify{
+		TaskPID:      event.TaskPID,
+		Timestamp:    event.Timestamp,
+		Inode:        uint64(event.Inode),
+		Access:       event.Access,
+		ModifyAttrib: event.ModifyAttrib,
+		CloseOpen:    event.CloseOpen,
+		Dentry:       event.Dentry,
+		Filename:     event.Filename,
+	})
+}
+
+// handleFsnotify handles the event triggered when
+// fsnotify dispatch call is invoked and is captured
+// by our trace probe.
+func (col *collector) handleFsnotify(
+	event eventFsnotify,
+) {
+	registry := col.registries[event.TaskPID]
+	if registry == nil {
+		return
+	}
+
+	// Judge whether it is dispatch condition.
+	switch registry.event.op {
+	case OpSymlink:
+		fallthrough
+	case OpLink:
+		fallthrough
+	case OpCreate, OpMkdir, OpMknod:
+		switch event.Dentry {
+		case 4:
+			if event.Inode != registry.targetInode {
+				return
+			}
+		default:
+			return
+		}
+	case OpAttrib:
+		switch event.ModifyAttrib {
+		case 2:
+			if event.Inode != registry.targetInode {
+				return
+			}
+		default:
+			return
+		}
+	case OpDelete, OpRmdir:
+		switch {
+		case event.ModifyAttrib == 2:
+			fallthrough
+		case event.Dentry == 16:
+			if event.Inode != registry.targetInode {
+				return
+			}
+		default:
+			return
+		}
+	case OpRename:
+		switch event.Dentry {
+		case 1:
+			if event.Inode != registry.sourceInode {
+				return
+			}
+		case 2:
+			if event.Inode != registry.targetInode {
+				return
+			}
+		default:
+			return
+		}
+	default:
+		return
+	}
+
+	// Dispatch the stored event at this point.
+	delete(col.registries, event.TaskPID)
+	registry.event.pid = event.TaskPID
+	registry.event.timestamp = event.Timestamp
+	_, targetInodes := registry.event.target.extract()
+	for _, inode := range targetInodes {
+		if subs, ok := col.dispatchMap.Load(inode); ok {
+			for _, sub := range subs.([]*subscriber) {
+				sub.dispatch(registry.event, event.Visited)
+			}
+		}
+	}
+	if registry.event.op&(OpRename|OpLink) != 0 {
+		_, sourceInodes := registry.event.source.extract()
+		for _, inode := range sourceInodes {
+			if subs, ok := col.dispatchMap.Load(inode); ok {
+				for _, sub := range subs.([]*subscriber) {
+					sub.dispatch(registry.event, event.Visited)
+				}
+			}
+		}
+	}
+}
+
+// Watcher is the subscription of the dispatch info.
+type Watcher struct {
+	C      <-chan Event
+	mgr    *Manager
+	cancel context.CancelFunc
+	sub    *subscriber
+	inodes []*inode.Inode
+	once   sync.Once
+}
+
+func (s *Watcher) Close() {
+	s.cancel()
+	s.once.Do(func() {
+		s.mgr.evict(s.sub)
+		for _, inode := range s.inodes {
+			inode.Unpin()
+		}
+		s.inodes = nil
+	})
+	runtime.SetFinalizer(s, nil)
+}
+
+// Manager is the manager for all directory events.
+type Manager struct {
+	ctx         context.Context
+	mtx         sync.Mutex
+	subsets     map[uint64]map[*subscriber]struct{}
+	dispatchMap *sync.Map
+	inodeMgr    *inode.Manager
+}
+
+func (m *Manager) evict(sub *subscriber) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	for inode := range sub.policies {
+		subset, ok := m.subsets[inode]
+		if !ok {
+			continue
+		}
+		delete(subset, sub)
+		if len(subset) == 0 {
+			delete(m.subsets, inode)
+			m.dispatchMap.Delete(inode)
+		}
+		var remainings []*subscriber
+		for remaining := range subset {
+			remainings = append(remainings, remaining)
+		}
+		m.dispatchMap.Store(inode, remainings)
+	}
+}
+
+func (m *Manager) emplace(sub *subscriber) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+	for inode := range sub.policies {
+		subset, ok := m.subsets[inode]
+		if !ok {
+			subset = make(map[*subscriber]struct{})
+			m.subsets[inode] = subset
+		}
+		subset[sub] = struct{}{}
+		var updated []*subscriber
+		for item := range subset {
+			updated = append(updated, item)
+		}
+		m.dispatchMap.Store(inode, updated)
+	}
+}
+
+type watchPoint struct {
+	name    string
+	watch   func(*inode.Manager) (*inode.Inode, error)
+	opFlags Op
+}
+
+type option struct {
+	watchPoints []watchPoint
+}
+
+// Option is the options for creating watcher.
+type Option func(*option)
+
+// WatchFile specifies a file for watching.
+func WatchFile(opFlags Op, file string) Option {
+	return func(opt *option) {
+		opt.watchPoints = append(opt.watchPoints, watchPoint{
+			name: file,
+			watch: func(mgr *inode.Manager) (*inode.Inode, error) {
+				return mgr.PinFile(file)
+			},
+			opFlags: opFlags,
+		})
+	}
+}
+
+// WatchDir specifies a directory for watching.
+func WatchDir(opFlags Op, dir string) Option {
+	return func(opt *option) {
+		opt.watchPoints = append(opt.watchPoints, watchPoint{
+			name: dir,
+			watch: func(mgr *inode.Manager) (*inode.Inode, error) {
+				return mgr.PinDir(dir)
+			},
+			opFlags: opFlags,
+		})
+	}
+}
+
+// WithOptions aggregates a set of options for execution.
+func WithOptions(opts ...Option) Option {
+	return func(option *option) {
+		for _, opt := range opts {
+			opt(option)
+		}
+	}
+}
+
+// Watch with specified options and returns error.
+func (mgr *Manager) Watch(opts ...Option) (*Watcher, error) {
+	var option option
+	WithOptions(opts...)(&option)
+
+	// Attempt to create pins for specified watchers.
+	created := false
+	ctx, cancel := context.WithCancel(mgr.ctx)
+	defer func() {
+		if !created {
+			cancel()
+		}
+	}()
+	eventCh := make(chan Event)
+	subscriber := &subscriber{
+		ctx:      ctx,
+		done:     new(uint8),
+		eventCh:  eventCh,
+		policies: make(map[uint64]dispatchPolicy),
+	}
+	result := &Watcher{
+		C:      eventCh,
+		mgr:    mgr,
+		cancel: cancel,
+		sub:    subscriber,
+	}
+	for _, watchPoint := range option.watchPoints {
+		pin, err := watchPoint.watch(mgr.inodeMgr)
+		if err != nil {
+			return nil, err
+		}
+		defer func() {
+			if !created {
+				pin.Unpin()
+			}
+		}()
+		subscriber.policies[pin.Inode()] = dispatchPolicy{
+			name:    watchPoint.name,
+			opFlags: watchPoint.opFlags,
+		}
+		subscriber.allOpFlags |= watchPoint.opFlags
+		result.inodes = append(result.inodes, pin)
+	}
+
+	// Attempt to emplace all the modifications to map
+	// and return the result.
+	defer func() {
+		if !created {
+			mgr.evict(subscriber)
+		}
+	}()
+	mgr.emplace(subscriber)
+	runtime.SetFinalizer(result, func(value *Watcher) {
+		value.Close()
+	})
+	created = true
+	return result, nil
+}
+
+// stackRcnotifyManager will attempt to create a rcnotify
+// manager and stack it for later operations.
+func stackRcnotifyManager(
+	next func(*Manager) error,
+	rootCtx context.Context, manager systracer.Manager,
+	inodeMgr *inode.Manager,
+) error {
+	dispatchMap := new(sync.Map)
+	result := &Manager{
+		ctx:         rootCtx,
+		subsets:     make(map[uint64]map[*subscriber]struct{}),
+		dispatchMap: dispatchMap,
+		inodeMgr:    inodeMgr,
+	}
+	collector := &collector{
+		registries:  make(map[uint32]*eventRegistry),
+		dispatchMap: dispatchMap,
+	}
+
+	// Attach to the fsnotify dispatcher first.
+	var fsnotifyHandler interface{}
+	fsnotifyHandler = collector.handleFsnotify_V2_6_32
+	if kversion.Current >= kversion.Must("5.9") {
+		fsnotifyHandler = collector.handleFsnotify_V5_9
+	}
+	fsnotify, _, err := manager.TraceKProbe(
+		"fsnotify", fsnotifyHandler)
+	if err != nil {
+		return err
+	}
+	defer fsnotify.Close()
+
+	// There's also fsnotify parent handler for those
+	// version >= 5.9, we will also register them here.
+	var fsnotifyParent systracer.Trace
+	if kversion.Current >= kversion.Must("5.9") {
+		fsnotifyParent, _, err = manager.TraceKProbe(
+			"__fsnotify_parent",
+			collector.handleFsnotifyParent_V5_9)
+		if err != nil {
+			return err
+		}
+		defer fsnotifyParent.Close()
+	}
+
+	// Define a collection of probe points and their
+	// associated probes for registering.
+	probes := map[string][]interface{}{
+		"security_inode_rename": {
+			collector.handleRenameSource,
+			collector.handleRenameTarget,
+		},
+		"security_inode_create": {
+			collector.handleCreate,
+		},
+		"security_inode_mknod": {
+			collector.handleMknod,
+		},
+		"security_inode_mkdir": {
+			collector.handleMkdir,
+		},
+		"security_inode_link": {
+			collector.handleLinkSource,
+			collector.handleLinkTarget,
+		},
+		"security_inode_symlink": {
+			collector.handleSymlink,
+		},
+		"security_inode_unlink": {
+			collector.handleUnlink,
+		},
+		"security_inode_rmdir": {
+			collector.handleRmdir,
+		},
+		"security_inode_setattr": {
+			collector.handleSetattr,
+		},
+	}
+	var lastSyncCh <-chan struct{}
+	var registries []systracer.Trace
+	for point, handlers := range probes {
+		for _, handler := range handlers {
+			registry, syncCh, err := manager.
+				TraceKProbe(point, handler)
+			if err != nil {
+				return errors.Wrapf(err,
+					"initializing %s", handler)
+			}
+			defer registry.Close()
+			lastSyncCh = syncCh
+			registries = append(registries, registry)
+		}
+	}
+
+	// Wait for synchronization of the kprobe registry.
+	select {
+	case <-rootCtx.Done():
+		return nil
+	case <-lastSyncCh:
+	}
+	fsnotify.SetEnabled(true)
+	if fsnotifyParent != nil {
+		fsnotifyParent.SetEnabled(true)
+	}
+	for _, registry := range registries {
+		registry.SetEnabled(true)
+	}
+	return next(result)
+}
+
+// Module is the DI module of the rcnotify manager.
+//
+// The module requires a context, a trace manager and
+// an inode manager, and injects a rcnotify manager.
+var Module = shaft.Stack(stackRcnotifyManager)

--- a/rcnotify/trace_386.go
+++ b/rcnotify/trace_386.go
@@ -1,0 +1,172 @@
+package rcnotify
+
+import (
+	"time"
+
+	"github.com/chaitin/systracer"
+)
+
+type eventFsnotify struct {
+	TaskPID      uint32
+	Timestamp    time.Time
+	Inode        uint64
+	Access       uint32
+	ModifyAttrib uint32
+	CloseOpen    uint32
+	Dentry       uint32
+	Filename     string
+	Visited      *uint8
+}
+
+type entryFsnotify_V2_6_32 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Inode        uint32 `tracing:"%ax"`
+	Access       uint32 `tracing:"%dx,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%dx,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%dx,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%dx,,bit[6:12]"`
+	Filename     string `tracing:"+8(+8(%sp))"`
+}
+
+type entryFsnotify_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Access       uint32 `tracing:"%ax,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%ax,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%ax,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%ax,,bit[6:12]"`
+	Dir          uint32 `tracing:"+4(%sp)"`
+	Filename     string `tracing:"+8(+8(%sp))"`
+	Inode        uint32 `tracing:"+12(%sp)`
+}
+
+type entryFsnotifyParent_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Filename     string `tracing:"+40(%ax)"`
+	Inode        uint64 `tracing:"+48(%ax)"`
+	Access       uint32 `tracing:"%dx,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%dx,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%dx,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%dx,,bit[6:12]"`
+}
+
+type path struct {
+	N0 systracer.StringAddr `tracing:"+28({1})"`
+	N1 systracer.StringAddr `tracing:"+28(+16({1}))"`
+	N2 systracer.StringAddr `tracing:"+28(+16(+16({1})))"`
+	N3 systracer.StringAddr `tracing:"+28(+16(+16(+16({1}))))"`
+	N4 systracer.StringAddr `tracing:"+28(+16(+16(+16(+16({1})))))"`
+	N5 systracer.StringAddr `tracing:"+28(+16(+16(+16(+16(+16({1}))))))"`
+	N6 systracer.StringAddr `tracing:"+28(+16(+16(+16(+16(+16(+16({1})))))))"`
+	N7 systracer.StringAddr `tracing:"+28(+16(+16(+16(+16(+16(+16(+16({1}))))))))"`
+	N8 systracer.StringAddr `tracing:"+28(+16(+16(+16(+16(+16(+16(+16(+16({1})))))))))"`
+
+	I0 uint64 `tracing:"+32({1})"`
+	I1 uint64 `tracing:"+32(+16({1}))"`
+	I2 uint64 `tracing:"+32(+16(+16({1})))"`
+	I3 uint64 `tracing:"+32(+16(+16(+16({1}))))"`
+	I4 uint64 `tracing:"+32(+16(+16(+16(+16({1})))))"`
+	I5 uint64 `tracing:"+32(+16(+16(+16(+16(+16({1}))))))"`
+	I6 uint64 `tracing:"+32(+16(+16(+16(+16(+16(+16({1})))))))"`
+	I7 uint64 `tracing:"+32(+16(+16(+16(+16(+16(+16(+16({1}))))))))"`
+	I8 uint64 `tracing:"+32(+16(+16(+16(+16(+16(+16(+16(+16({1})))))))))"`
+	I9 uint64 `tracing:"+32(+16(+16(+16(+16(+16(+16(+16(+16(+16({1}))))))))))"`
+}
+
+func (d path) extract() ([]string, []uint64) {
+	nodes := []systracer.StringAddr{
+		d.N0, d.N1, d.N2, d.N3, d.N4, d.N5, d.N6, d.N7, d.N8,
+	}
+	resultPath := extractPathComponent(nodes)
+	inodes := []uint64{
+		d.I0, d.I1, d.I2, d.I3, d.I4, d.I5, d.I6, d.I7, d.I8, d.I9,
+	}
+	resultInodes := inodes[:len(resultPath)+1]
+	return resultPath, resultInodes
+}
+
+type entrySecurityInodeRename struct {
+	SrcDir uint64 `tracing:"%ax"`
+	DstDir uint64 `tracing:"%cx"`
+}
+
+type entrySecurityInodeRenameSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Source path `tracing:"%dx"`
+}
+
+type entrySecurityInodeRenameTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Target path `tracing:"+4(%sp)"`
+}
+
+type entrySecurityInodeCreate struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%ax"`
+	Path path   `tracing:"%dx"`
+	Mode uint16 `tracing:"%cx"`
+}
+
+type entrySecurityInodeMknod struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%ax"`
+	Path path   `tracing:"%dx"`
+	Mode uint16 `tracing:"%cx"`
+	Dev  uint32 `tracing:"+4(%sp)"`
+}
+
+type entrySecurityInodeMkdir struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%ax"`
+	Path path   `tracing:"%dx"`
+	Mode uint16 `tracing:"%cx"`
+}
+
+type entrySecurityInodeLink struct {
+	Dir uint64 `tracing:"%dx"`
+}
+
+type entrySecurityInodeLinkSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Source path `tracing:"%ax"`
+}
+
+type entrySecurityInodeLinkTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Target path `tracing:"%cx"`
+}
+
+type entrySecurityInodeSymlink struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%ax"`
+	Path path   `tracing:"%dx"`
+	Name string `tracing:"%cx"`
+}
+
+type entrySecurityInodeUnlink struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%dx"`
+}
+
+type entrySecurityInodeRmdir struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%dx"`
+}
+
+type entrySecurityInodeSetattr struct {
+	systracer.ProbeEvent
+	Path  path   `tracing:"%di"`
+	Valid uint32 `tracing:"+0(%si)"`
+	Mode  uint16 `tracing:"+4(%si)"`
+	Uid   uint32 `tracing:"+8(%si)"`
+	Gid   uint32 `tracing:"+12(%si)"`
+}

--- a/rcnotify/trace_amd64.go
+++ b/rcnotify/trace_amd64.go
@@ -1,0 +1,172 @@
+package rcnotify
+
+import (
+	"time"
+
+	"github.com/chaitin/systracer"
+)
+
+type eventFsnotify struct {
+	TaskPID      uint32
+	Timestamp    time.Time
+	Inode        uint64
+	Access       uint32
+	ModifyAttrib uint32
+	CloseOpen    uint32
+	Dentry       uint32
+	Filename     string
+	Visited      *uint8
+}
+
+type entryFsnotify_V2_6_32 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Inode        uint64 `tracing:"%di"`
+	Access       uint32 `tracing:"%si,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%si,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%si,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%si,,bit[6:12]"`
+	Filename     string `tracing:"+8(%r8)"`
+}
+
+type entryFsnotify_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Access       uint32 `tracing:"%di,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%di,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%di,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%di,,bit[6:12]"`
+	Dir          uint64 `tracing:"%cx"`
+	Filename     string `tracing:"+8(%r8)"`
+	Inode        uint64 `tracing:"%r9"`
+}
+
+type entryFsnotifyParent_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Filename     string `tracing:"+40(%di)"`
+	Inode        uint64 `tracing:"+48(%di)"`
+	Access       uint32 `tracing:"%si,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%si,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%si,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%si,,bit[6:12]"`
+}
+
+type path struct {
+	N0 systracer.StringAddr `tracing:"+40({1})"`
+	N1 systracer.StringAddr `tracing:"+40(+24({1}))"`
+	N2 systracer.StringAddr `tracing:"+40(+24(+24({1})))"`
+	N3 systracer.StringAddr `tracing:"+40(+24(+24(+24({1}))))"`
+	N4 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24({1})))))"`
+	N5 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24({1}))))))"`
+	N6 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24({1})))))))"`
+	N7 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24(+24({1}))))))))"`
+	N8 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24(+24(+24({1})))))))))"`
+
+	I0 uint64 `tracing:"+48({1})"`
+	I1 uint64 `tracing:"+48(+24({1}))"`
+	I2 uint64 `tracing:"+48(+24(+24({1})))"`
+	I3 uint64 `tracing:"+48(+24(+24(+24({1}))))"`
+	I4 uint64 `tracing:"+48(+24(+24(+24(+24({1})))))"`
+	I5 uint64 `tracing:"+48(+24(+24(+24(+24(+24({1}))))))"`
+	I6 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24({1})))))))"`
+	I7 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24({1}))))))))"`
+	I8 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24(+24({1})))))))))"`
+	I9 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24(+24(+24({1}))))))))))"`
+}
+
+func (d path) extract() ([]string, []uint64) {
+	nodes := []systracer.StringAddr{
+		d.N0, d.N1, d.N2, d.N3, d.N4, d.N5, d.N6, d.N7, d.N8,
+	}
+	resultPath := extractPathComponent(nodes)
+	inodes := []uint64{
+		d.I0, d.I1, d.I2, d.I3, d.I4, d.I5, d.I6, d.I7, d.I8, d.I9,
+	}
+	resultInodes := inodes[:len(resultPath)+1]
+	return resultPath, resultInodes
+}
+
+type entrySecurityInodeRename struct {
+	SrcDir uint64 `tracing:"%di"`
+	DstDir uint64 `tracing:"%dx"`
+}
+
+type entrySecurityInodeRenameSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Source path `tracing:"%si"`
+}
+
+type entrySecurityInodeRenameTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Target path `tracing:"%cx"`
+}
+
+type entrySecurityInodeCreate struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%di"`
+	Path path   `tracing:"%si"`
+	Mode uint16 `tracing:"%dx"`
+}
+
+type entrySecurityInodeMknod struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%di"`
+	Path path   `tracing:"%si"`
+	Mode uint16 `tracing:"%dx"`
+	Dev  uint32 `tracing:"%cx"`
+}
+
+type entrySecurityInodeMkdir struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%di"`
+	Path path   `tracing:"%si"`
+	Mode uint16 `tracing:"%dx"`
+}
+
+type entrySecurityInodeLink struct {
+	Dir uint64 `tracing:"%si"`
+}
+
+type entrySecurityInodeLinkSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Source path `tracing:"%di"`
+}
+
+type entrySecurityInodeLinkTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Target path `tracing:"%dx"`
+}
+
+type entrySecurityInodeSymlink struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%di"`
+	Path path   `tracing:"%si"`
+	Name string `tracing:"%dx"`
+}
+
+type entrySecurityInodeUnlink struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%si"`
+}
+
+type entrySecurityInodeRmdir struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%si"`
+}
+
+type entrySecurityInodeSetattr struct {
+	systracer.ProbeEvent
+	Path  path   `tracing:"%di"`
+	Valid uint32 `tracing:"+0(%si)"`
+	Mode  uint16 `tracing:"+4(%si)"`
+	Uid   uint32 `tracing:"+8(%si)"`
+	Gid   uint32 `tracing:"+12(%si)"`
+}

--- a/rcnotify/trace_arm64.go
+++ b/rcnotify/trace_arm64.go
@@ -1,0 +1,172 @@
+package rcnotify
+
+import (
+	"time"
+
+	"github.com/chaitin/systracer"
+)
+
+type eventFsnotify struct {
+	TaskPID      uint32
+	Timestamp    time.Time
+	Inode        uint64
+	Access       uint32
+	ModifyAttrib uint32
+	CloseOpen    uint32
+	Dentry       uint32
+	Filename     string
+	Visited      *uint8
+}
+
+type entryFsnotify_V2_6_32 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Inode        uint64 `tracing:"%x0"`
+	Access       uint32 `tracing:"%x1,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%x1,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%x1,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%x1,,bit[6:12]"`
+	Filename     string `tracing:"+8(%x4)"`
+}
+
+type entryFsnotify_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Access       uint32 `tracing:"%x0,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%x0,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%x0,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%x0,,bit[6:12]"`
+	Dir          uint64 `tracing:"%x3"`
+	Filename     string `tracing:"+8(%x4)"`
+	Inode        uint64 `tracing:"%x5"`
+}
+
+type entryFsnotifyParent_V5_9 struct {
+	systracer.ProbeEvent
+	systracer.Condition `tracing:"(ModifyAttrib == 2) || (Dentry != 0)"`
+
+	Filename     string `tracing:"+40(%x0)"`
+	Inode        uint64 `tracing:"+48(%x0)"`
+	Access       uint32 `tracing:"%x1,Access == 0,bit[0]"`
+	ModifyAttrib uint32 `tracing:"%x1,,bit[1:2]"`
+	CloseOpen    uint32 `tracing:"%x1,CloseOpen == 0,bit[3:5]"`
+	Dentry       uint32 `tracing:"%x1,,bit[6:12]"`
+}
+
+type path struct {
+	N0 systracer.StringAddr `tracing:"+40({1})"`
+	N1 systracer.StringAddr `tracing:"+40(+24({1}))"`
+	N2 systracer.StringAddr `tracing:"+40(+24(+24({1})))"`
+	N3 systracer.StringAddr `tracing:"+40(+24(+24(+24({1}))))"`
+	N4 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24({1})))))"`
+	N5 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24({1}))))))"`
+	N6 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24({1})))))))"`
+	N7 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24(+24({1}))))))))"`
+	N8 systracer.StringAddr `tracing:"+40(+24(+24(+24(+24(+24(+24(+24(+24({1})))))))))"`
+
+	I0 uint64 `tracing:"+48({1})"`
+	I1 uint64 `tracing:"+48(+24({1}))"`
+	I2 uint64 `tracing:"+48(+24(+24({1})))"`
+	I3 uint64 `tracing:"+48(+24(+24(+24({1}))))"`
+	I4 uint64 `tracing:"+48(+24(+24(+24(+24({1})))))"`
+	I5 uint64 `tracing:"+48(+24(+24(+24(+24(+24({1}))))))"`
+	I6 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24({1})))))))"`
+	I7 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24({1}))))))))"`
+	I8 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24(+24({1})))))))))"`
+	I9 uint64 `tracing:"+48(+24(+24(+24(+24(+24(+24(+24(+24(+24({1}))))))))))"`
+}
+
+func (d path) extract() ([]string, []uint64) {
+	nodes := []systracer.StringAddr{
+		d.N0, d.N1, d.N2, d.N3, d.N4, d.N5, d.N6, d.N7, d.N8,
+	}
+	resultPath := extractPathComponent(nodes)
+	inodes := []uint64{
+		d.I0, d.I1, d.I2, d.I3, d.I4, d.I5, d.I6, d.I7, d.I8, d.I9,
+	}
+	resultInodes := inodes[:len(resultPath)+1]
+	return resultPath, resultInodes
+}
+
+type entrySecurityInodeRename struct {
+	SrcDir uint64 `tracing:"%x0"`
+	DstDir uint64 `tracing:"%x2"`
+}
+
+type entrySecurityInodeRenameSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Source path `tracing:"%x1"`
+}
+
+type entrySecurityInodeRenameTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeRename
+	Target path `tracing:"%x3"`
+}
+
+type entrySecurityInodeCreate struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%x0"`
+	Path path   `tracing:"%x1"`
+	Mode uint16 `tracing:"%x2"`
+}
+
+type entrySecurityInodeMknod struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%x0"`
+	Path path   `tracing:"%x1"`
+	Mode uint16 `tracing:"%x2"`
+	Dev  uint32 `tracing:"%x3"`
+}
+
+type entrySecurityInodeMkdir struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%x0"`
+	Path path   `tracing:"%x1"`
+	Mode uint16 `tracing:"%x2"`
+}
+
+type entrySecurityInodeLink struct {
+	Dir uint64 `tracing:"%x1"`
+}
+
+type entrySecurityInodeLinkSource struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Source path `tracing:"%x0"`
+}
+
+type entrySecurityInodeLinkTarget struct {
+	systracer.ProbeEvent
+	Event  entrySecurityInodeLink
+	Target path `tracing:"%x2"`
+}
+
+type entrySecurityInodeSymlink struct {
+	systracer.ProbeEvent
+	Dir  uint64 `tracing:"%x0"`
+	Path path   `tracing:"%x1"`
+	Name string `tracing:"%x2"`
+}
+
+type entrySecurityInodeUnlink struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%x1"`
+}
+
+type entrySecurityInodeRmdir struct {
+	systracer.ProbeEvent
+	Path path `tracing:"%x1"`
+}
+
+type entrySecurityInodeSetattr struct {
+	systracer.ProbeEvent
+	Path  path   `tracing:"%x0"`
+	Valid uint32 `tracing:"+0(%x1)"`
+	Mode  uint16 `tracing:"+4(%x1)"`
+	Uid   uint32 `tracing:"+8(%x1)"`
+	Gid   uint32 `tracing:"+12(%x1)"`
+}


### PR DESCRIPTION
1.  支持获取 inode 在内核中的地址并锁定 inode。
2. 支持文件递归监控 rcnotify 和 `--watch` 标志。